### PR TITLE
✅Exclude Windows Calculator tests from CD

### DIFF
--- a/.github/workflows/Run_desktop_tests.yml
+++ b/.github/workflows/Run_desktop_tests.yml
@@ -53,7 +53,7 @@ jobs:
           env:
             TestResultPath: ${{ inputs.test_results_path }}
         - name: Run tests
-          run: dotnet test TestWare.Samples.WinAppDriver.Desktop.dll --logger "trx;LogFileName=results.trx" --results-directory "${{ inputs.test_results_path }}"
+          run: dotnet test TestWare.Samples.WinAppDriver.Desktop.dll --logger "trx;LogFileName=results.trx" --results-directory "${{ inputs.test_results_path }}"  --filter TestCategory!=WindowsCalculator
         - name: Archive DESKTOP (${{ matrix.os }}) screenshots
           if: always()
           uses: actions/upload-artifact@v2


### PR DESCRIPTION
# Exclude Windows Calculator tests from CD

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](./../CONTRIBUTING.md) and [Code of Conduct](./../CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Exclude Windows Calculator tests from CD

## Description

Exclude Windows Calculator tests from CD due to Windows 2022 server machine does not have a Windows calculator that is build on UWP. The windows calculator on Windows 2022 server is a win32 application

Fixes #37 
